### PR TITLE
Add buildkite and earthfile configs for CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+env:
+  FORCE_COLOR: 1
+  GIT_TERMINAL_PROMPT: 0
+
+steps:
+  - command: >
+      earthly +build &&
+      aws s3 sync protocol s3://recordreplay-website/protocol/ &&
+      aws cloudfront create-invalidation --distribution-id E3U30CHVUQVFAF --paths "/protocol/*"
+    agents:
+      - "earthly=true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 _site/
 devtools-protocol/
+protocol/
 
 .jekyll-metadata
 node_modules/

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,13 @@
+VERSION --parallel-load 0.6
+
+FROM --platform linux/amd64 node:16.13-bullseye-slim
+WORKDIR /usr/build
+ENV EARTHLY=true
+
+build:
+  COPY . .
+  RUN npm ci
+  RUN npm i @recordreplay/protocol@latest
+  RUN npm run prep
+  RUN npm run build
+  SAVE ARTIFACT protocol AS LOCAL protocol

--- a/prep-tot-protocol-files.sh
+++ b/prep-tot-protocol-files.sh
@@ -3,7 +3,7 @@ set -x
 
 # Machine-specific path, naturally
 local_script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-protocol_repo_path="$local_script_path/../backend/packages/protocol"
+protocol_repo_path="$local_script_path/node_modules/@recordreplay/protocol"
 
 protocol_path="$protocol_repo_path/json/protocol.json"
 


### PR DESCRIPTION
This will allow us to run the `npm run prep` and `npm run build` steps
in Buildkite, and then we will add a step for uploading the output
artifacts to S3.